### PR TITLE
Fixed error with missing var keyword in Validator.js.

### DIFF
--- a/Scripts/view/base/Validator.js
+++ b/Scripts/view/base/Validator.js
@@ -140,7 +140,7 @@ Validator.prototype.$buildRulesFromDedicatedAtttributes = function() {
 	var attrs = this.$().getAttributes("data-validate-(\\S+)");
     var clsDesc;
     if (attrs != null) {
-        for (attr in attrs) {
+        for (var attr in attrs) {
             if (Validator.validatorsRegistry[attr] != null) {
                 clsDesc = {
                     className: Validator.validatorsRegistry[attr],


### PR DESCRIPTION
Fixed error with missing var keyword in Validator.js.